### PR TITLE
Iter8 ui fixes (#1708)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: node_js
 dist: trusty
 node_js:
   - '12'
+before_install: # if "install" is overridden
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.4
+  - export PATH="$HOME/.yarn/bin:$PATH"
 cache:
-  yarn: true
   directories:
     - node_modules
 install: yarn --frozen-lockfile --non-interactive || (echo 'package.json is not in sync with yarn.lock, check that you include yarn.lock' && false)

--- a/src/components/DefaultSecondaryMasthead/DefaultSecondaryMasthead.tsx
+++ b/src/components/DefaultSecondaryMasthead/DefaultSecondaryMasthead.tsx
@@ -3,17 +3,29 @@ import { Title } from '@patternfly/react-core';
 import SecondaryMasthead from '../Nav/SecondaryMasthead';
 import NamespaceDropdownContainer from '../NamespaceDropdown';
 
-const titles = ['applications', 'workloads', 'services', 'istio', 'istio/new'];
+const titles = [
+  'applications',
+  'workloads',
+  'services',
+  'istio',
+  'istio/new',
+  'extensions/iter8',
+  'extensions/iter8/new'
+];
 export default class DefaultSecondaryMasthead extends React.Component {
   showTitle() {
-    const path = window.location.pathname.replace('/console/', '');
-
+    let path = window.location.pathname;
+    path = path.substr(path.lastIndexOf('/console') + '/console'.length + 1);
     if (titles.includes(path)) {
       let title = path.charAt(0).toUpperCase() + path.slice(1);
       if (path === 'istio/new') {
         title = 'Create New Istio Config';
       } else if (path === 'istio') {
         title = 'Istio Config';
+      } else if (path === 'extensions/iter8') {
+        title = 'Iter8 Experiments';
+      } else if (path === 'extensions/iter8/new') {
+        title = 'Create New Iter8 Experiment';
       }
       return (
         <Title headingLevel="h1" size="4xl" style={{ margin: '20px 0 20px' }}>
@@ -27,7 +39,6 @@ export default class DefaultSecondaryMasthead extends React.Component {
 
   render() {
     const title = this.showTitle();
-
     return (
       <SecondaryMasthead title={title ? true : false}>
         <NamespaceDropdownContainer disabled={false} />

--- a/src/components/Nav/Menu.tsx
+++ b/src/components/Nav/Menu.tsx
@@ -54,7 +54,9 @@ class Menu extends React.Component<MenuProps, MenuState> {
       .filter(item => {
         // Extensions are conditionally rendered
         if (item.title === '3scale Config') {
-          return serverConfig.extensions!.threescale.enabled;
+          return serverConfig.extensions!.threescale!.enabled;
+        } else if (item.title === 'Iter8 Experiments') {
+          return serverConfig.extensions!.iter8!.enabled;
         }
         return true;
       })

--- a/src/components/Nav/RenderPage.tsx
+++ b/src/components/Nav/RenderPage.tsx
@@ -28,6 +28,8 @@ class RenderPage extends React.Component<{ isGraph: boolean }> {
         // Extensions are conditionally rendered
         if (route.path.startsWith('/extensions/threescale') && serverConfig.extensions!.threescale.enabled) {
           return true;
+        } else if (route.path.includes('iter8') && serverConfig.extensions!.iter8.enabled) {
+          return true;
         }
         return false;
       })

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -111,6 +111,10 @@ const conf = {
         `api/namespaces/${namespace}/istio/${objectType}/${object}`,
       istioConfigDetailSubtype: (namespace: string, objectType: string, objectSubtype: string, object: string) =>
         `api/namespaces/${namespace}/istio/${objectType}/${objectSubtype}/${object}`,
+      iter8: `api/iter8`,
+      iter8Experiments: `api/iter8/experiments`,
+      iter8ExperimentsByNamespace: (namespace: string) => `api/iter8/namespaces/${namespace}/experiments`,
+      iter8Experiment: (namespace: string, name: string) => `api/iter8/namespaces/${namespace}/experiments/${name}`,
       istioPermissions: 'api/istio/permissions',
       jaeger: 'api/jaeger',
       jaegerTraces: (namespace: string, service: string) => `api/namespaces/${namespace}/services/${service}/traces`,

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.tsx
@@ -1,0 +1,603 @@
+import * as React from 'react';
+import { Iter8Info } from '../../../../types/Iter8';
+import { style } from 'typestyle';
+import * as API from '../../../../services/Api';
+import * as AlertUtils from '../../../../utils/AlertUtils';
+import {
+  ActionGroup,
+  Button,
+  ButtonVariant,
+  Form,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  Grid,
+  GridItem,
+  TextInput
+} from '@patternfly/react-core';
+import history from '../../../../app/History';
+import { RenderContent } from '../../../../components/Nav/Page';
+import Namespace from '../../../../types/Namespace';
+import ExperimentCriteriaForm from './ExperimentCriteriaForm';
+import { PromisesRegistry } from '../../../../utils/CancelablePromises';
+import { KialiAppState } from '../../../../store/Store';
+import { activeNamespacesSelector } from '../../../../store/Selectors';
+import { connect } from 'react-redux';
+
+interface Props {
+  activeNamespaces: Namespace[];
+}
+
+interface State {
+  iter8Info: Iter8Info;
+  experiment: ExperimentSpec;
+  namespaces: string[];
+  services: string[];
+  workloads: string[];
+}
+
+interface ExperimentSpec {
+  name: string;
+  namespace: string;
+  service: string;
+  apiversion: string;
+  baseline: string;
+  candidate: string;
+  // canaryVersion: string;
+  trafficControl: TrafficControl;
+  criterias: Criteria[];
+}
+
+interface TrafficControl {
+  algorithm: string;
+  interval: string;
+  maxIterations: number;
+  maxTrafficPercentage: number;
+  trafficStepSize: number;
+}
+
+export interface Criteria {
+  metric: string;
+  toleranceType: string;
+  tolerance: number;
+  sampleSize: number;
+  stopOnFailure: boolean;
+}
+
+// Style constants
+const containerPadding = style({ padding: '20px 20px 20px 20px' });
+
+const algorithms = ['check_and_increment', 'epsilon_greedy'];
+
+class ExperimentCreatePage extends React.Component<Props, State> {
+  private promises = new PromisesRegistry();
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      iter8Info: {
+        enabled: false
+      },
+      experiment: {
+        name: '',
+        namespace: 'default',
+        apiversion: 'v1',
+        service: '',
+        baseline: '',
+        candidate: '',
+        trafficControl: {
+          algorithm: 'check_and_increment',
+          interval: '30s',
+          maxIterations: 100,
+          maxTrafficPercentage: 50,
+          trafficStepSize: 2
+        },
+        criterias: []
+      },
+      namespaces: [],
+      services: [],
+      workloads: []
+    };
+  }
+
+  componentWillUnmount() {
+    this.promises.cancelAll();
+  }
+
+  fetchServices = () => {
+    if (this.props.activeNamespaces.length === 1) {
+      const ns = this.props.activeNamespaces[0];
+      if (!this.promises.has('servicesByNamespace')) {
+        this.promises
+          .register('servicesByNamespace', API.getServices(ns.name))
+          .then(response => {
+            const services: string[] = response.data.services.map(svc => svc.name);
+            if (services.length > 0) {
+              this.promises
+                .register('firstServiceDetails', API.getServiceDetail(ns.name, services[0], false))
+                .then(responseDetail => {
+                  let workloads: string[] = [];
+                  if (responseDetail.workloads) {
+                    workloads = responseDetail.workloads.map(w => w.name);
+                  }
+                  this.setState(prevState => {
+                    prevState.experiment.service = services[0];
+                    if (workloads.length > 0) {
+                      prevState.experiment.baseline = workloads[0];
+                      prevState.experiment.candidate = workloads[0];
+                    } else {
+                      prevState.experiment.baseline = '';
+                      prevState.experiment.candidate = '';
+                    }
+                    return {
+                      services: services,
+                      workloads: workloads,
+                      experiment: prevState.experiment
+                    };
+                  });
+                  this.promises.cancel('firstServiceDetails');
+                })
+                .catch(svcDetailError => {
+                  if (!svcDetailError.isCanceled) {
+                    AlertUtils.addError('Could not fetch Service Detail.', svcDetailError);
+                  }
+                });
+            }
+            // Clean promise from register
+            this.promises.cancel('servicesByNamespace');
+          })
+          .catch(svcError => {
+            if (!svcError.isCanceled) {
+              AlertUtils.addError('Could not fetch Services list.', svcError);
+            }
+          });
+      }
+    }
+  };
+
+  fetchWorkloads = (namespace, serviceName: string) => {
+    this.promises
+      .register('serviceDetails', API.getServiceDetail(namespace, serviceName, false))
+      .then(responseDetail => {
+        let workloads: string[] = [];
+        if (responseDetail.workloads) {
+          workloads = responseDetail.workloads.map(w => w.name);
+        }
+        this.setState(prevState => {
+          if (workloads.length > 0) {
+            prevState.experiment.baseline = workloads[0];
+            prevState.experiment.candidate = workloads[0];
+          } else {
+            prevState.experiment.baseline = '';
+            prevState.experiment.candidate = '';
+          }
+          return {
+            workloads: workloads,
+            experiment: prevState.experiment
+          };
+        });
+      })
+      .catch(svcDetailError => {
+        if (!svcDetailError.isCanceled) {
+          AlertUtils.addError('Could not fetch Service Detail.', svcDetailError);
+        }
+      });
+  };
+
+  componentDidMount() {
+    this.fetchServices();
+  }
+
+  componentDidUpdate(prevProps: Props, _prevState: State) {
+    if (
+      this.props.activeNamespaces.length === 1 &&
+      (prevProps.activeNamespaces.length !== 1 ||
+        (prevProps.activeNamespaces.length === 1 && this.props.activeNamespaces[0] !== prevProps.activeNamespaces[0]) ||
+        this.state.services.length === 0)
+    ) {
+      this.fetchServices();
+    }
+  }
+
+  // Invoke the history object to update and URL and start a routing
+  goExperimentsPage = () => {
+    history.push('/extensions/iter8');
+  };
+
+  // Updates state with modifications of the new/editing handler
+  changeExperiment = (field: string, value: string) => {
+    this.setState(prevState => {
+      const newExperiment = prevState.experiment;
+      switch (field) {
+        case 'name':
+          newExperiment.name = value.trim();
+          break;
+        case 'namespace':
+          newExperiment.namespace = value.trim();
+          break;
+        case 'service':
+          newExperiment.service = value.trim();
+          break;
+        case 'algorithm':
+          newExperiment.trafficControl.algorithm = value.trim();
+          break;
+        case 'baseline':
+          newExperiment.baseline = value.trim();
+          break;
+        case 'candidate':
+          newExperiment.candidate = value.trim();
+          break;
+        case 'kubernets':
+          newExperiment.apiversion = 'v1';
+          break;
+        case 'knative':
+          newExperiment.apiversion = 'serving.knative.dev/v1alpha1';
+          break;
+        case 'metricName':
+          newExperiment.criterias[0].metric = value.trim();
+          break;
+        case 'toleranceType':
+          newExperiment.criterias[0].toleranceType = value.trim();
+          break;
+        case 'interval':
+          newExperiment.trafficControl.interval = value.trim();
+          break;
+        default:
+      }
+      return {
+        experiment: newExperiment
+      };
+    });
+  };
+
+  // Updates state with modifications of the new/editing handler
+  changeExperimentNumber = (field: string, value: number) => {
+    this.setState(prevState => {
+      const newExperiment = prevState.experiment;
+      switch (field) {
+        case 'maxIteration':
+          newExperiment.trafficControl.maxIterations = value;
+          break;
+        case 'maxTrafficPercentage':
+          newExperiment.trafficControl.maxTrafficPercentage = value;
+          break;
+        case 'trafficStepSize':
+          newExperiment.trafficControl.trafficStepSize = value;
+          break;
+        case 'sampleSize':
+          newExperiment.criterias[0].sampleSize = value;
+          break;
+        case 'tolerance':
+          newExperiment.criterias[0].tolerance = value;
+          break;
+        default:
+      }
+      return {
+        experiment: newExperiment
+      };
+    });
+  };
+
+  // It invokes backend to create  a new experiment
+  createExperiment = () => {
+    if (this.props.activeNamespaces.length === 1) {
+      const ns = this.props.activeNamespaces[0];
+      this.promises
+        .register('Create Iter8 Experiment', API.createExperiment(ns.name, JSON.stringify(this.state.experiment)))
+        .then(_ => this.goExperimentsPage())
+        .catch(error => AlertUtils.addError('Could not create Experiment.', error));
+    }
+  };
+
+  isMainFormValid = (): boolean => {
+    return (
+      this.state.experiment.name !== '' &&
+      this.state.experiment.service !== '' &&
+      this.props.activeNamespaces.length === 1 &&
+      this.state.experiment.baseline !== '' &&
+      this.state.experiment.candidate !== ''
+    );
+  };
+
+  isTCFormValid = (): boolean => {
+    return (
+      this.state.experiment.trafficControl.interval !== '' && this.state.experiment.trafficControl.maxIterations > 0
+    );
+  };
+
+  isSCFormValid = (): boolean => {
+    return this.state.experiment.criterias.length > 0;
+  };
+
+  render() {
+    const isNamespacesValid = this.props.activeNamespaces.length === 1;
+    const isFormValid = this.isMainFormValid() && this.isTCFormValid() && this.isSCFormValid();
+    // @ts-ignore
+    return (
+      <>
+        <RenderContent>
+          <div className={containerPadding}>
+            <Form isHorizontal={true}>
+              <FormGroup
+                fieldId="name"
+                label="Experiment Name"
+                isRequired={true}
+                isValid={this.state.experiment.name !== ''}
+                helperTextInvalid="Name cannot be empty"
+              >
+                <TextInput
+                  id="name"
+                  value={this.state.experiment.name}
+                  placeholder="Experiment Name"
+                  onChange={value => this.changeExperiment('name', value)}
+                />
+              </FormGroup>
+
+              <Grid gutter="md">
+                <GridItem span={6}>
+                  <FormGroup
+                    fieldId="service"
+                    label="Target Service"
+                    isRequired={true}
+                    isValid={this.state.experiment.service !== ''}
+                    helperText="Target Service specifies the reference to experiment targets (i.e. reviews)"
+                    helperTextInvalid="Target Service cannot be empty"
+                  >
+                    <FormSelect
+                      id="service"
+                      value={this.state.experiment.service}
+                      placeholder="Target Service"
+                      onChange={value => {
+                        this.changeExperiment('service', value);
+                        if (this.props.activeNamespaces.length === 1) {
+                          const ns = this.props.activeNamespaces[0].name;
+                          this.fetchWorkloads(ns, value);
+                        }
+                      }}
+                    >
+                      {this.state.services.map((svc, index) => (
+                        <FormSelectOption label={svc} key={'service' + index} value={svc} />
+                      ))}
+                    </FormSelect>
+                  </FormGroup>
+                </GridItem>
+                <GridItem span={6}>
+                  <FormGroup
+                    label="Namespaces"
+                    isRequired={true}
+                    fieldId="namespaces"
+                    helperText={'Select namespace where this configuration will be applied'}
+                    helperTextInvalid={'Only one namespace should be selected'}
+                    isValid={isNamespacesValid}
+                  >
+                    <TextInput
+                      value={this.props.activeNamespaces.map(n => n.name).join(',')}
+                      isRequired={true}
+                      type="text"
+                      id="namespaces"
+                      aria-describedby="namespaces"
+                      name="namespaces"
+                      isDisabled={true}
+                      isValid={isNamespacesValid}
+                    />
+                  </FormGroup>
+                </GridItem>
+              </Grid>
+              <Grid gutter="md">
+                <GridItem span={6}>
+                  <FormGroup
+                    fieldId="baseline"
+                    label="Baseline"
+                    isRequired={true}
+                    isValid={this.state.experiment.baseline !== ''}
+                    helperText="The baseline deployment of the target service (i.e. reviews-v1)"
+                    helperTextInvalid="Baseline deployment cannot be empty"
+                  >
+                    <FormSelect
+                      id="baseline"
+                      value={this.state.experiment.baseline}
+                      placeholder="Baseline Deployment"
+                      onChange={value => this.changeExperiment('baseline', value)}
+                    >
+                      {this.state.workloads.map((wk, index) => (
+                        <FormSelectOption label={wk} key={'workloadBaseline' + index} value={wk} />
+                      ))}
+                    </FormSelect>
+                  </FormGroup>
+                </GridItem>
+                <GridItem span={6}>
+                  <FormGroup
+                    fieldId="candidate"
+                    label="Candidate"
+                    isRequired={true}
+                    isValid={this.state.experiment.candidate !== ''}
+                    helperText="The candidate deployment of the target service (i.e. reviews-v2)"
+                    helperTextInvalid="Candidate deployment cannot be empty"
+                  >
+                    <FormSelect
+                      id="candidate"
+                      value={this.state.experiment.candidate}
+                      placeholder="Candidate Deployment"
+                      onChange={value => this.changeExperiment('candidate', value)}
+                    >
+                      {this.state.workloads.map((wk, index) => (
+                        <FormSelectOption label={wk} key={'workloadCandidate' + index} value={wk} />
+                      ))}
+                    </FormSelect>
+                  </FormGroup>
+                </GridItem>
+              </Grid>
+              <hr />
+              <h1 className="pf-c-title pf-m-xl">Traffic Control</h1>
+              <Grid gutter="md">
+                <GridItem span={6}>
+                  <FormGroup
+                    fieldId="interval"
+                    label="Interval"
+                    isValid={this.state.experiment.trafficControl.interval !== ''}
+                    helperText="Frequency with which the controller calls the analytics service"
+                    helperTextInvalid="Interval cannot be empty"
+                  >
+                    <TextInput
+                      id="interval"
+                      value={this.state.experiment.trafficControl.interval}
+                      placeholder="Time interval i.e. 30s"
+                      onChange={value => this.changeExperiment('interval', value)}
+                    />
+                  </FormGroup>
+                </GridItem>
+                <GridItem span={6}>
+                  <FormGroup
+                    fieldId="maxIteration"
+                    label="Maximum Iteration"
+                    isValid={this.state.experiment.trafficControl.maxIterations > 0}
+                    helperText="Maximum number of iterations for this experiment"
+                    helperTextInvalid="Maximun Iteration cannot be empty"
+                  >
+                    <TextInput
+                      id="maxIteration"
+                      type="number"
+                      value={this.state.experiment.trafficControl.maxIterations}
+                      placeholder="Maximum Iteration"
+                      onChange={value => this.changeExperimentNumber('maxIteration', Number(value))}
+                    />
+                  </FormGroup>
+                </GridItem>
+              </Grid>
+              <Grid gutter="md">
+                <GridItem span={6}>
+                  <FormGroup
+                    fieldId="maxTrafficPercentage"
+                    label="Maximum Traffic Percentage"
+                    isValid={
+                      this.state.experiment.trafficControl.maxTrafficPercentage >= 0 &&
+                      this.state.experiment.trafficControl.maxTrafficPercentage <= 100
+                    }
+                    helperText="The maximum traffic percentage to send to the candidate during an experiment"
+                    helperTextInvalid="Maximum Traffic Percentage must be between 0 and 100"
+                  >
+                    <TextInput
+                      id="maxTrafficPercentage"
+                      type="number"
+                      value={this.state.experiment.trafficControl.maxTrafficPercentage}
+                      placeholder="Service Name"
+                      onChange={value => this.changeExperimentNumber('maxTrafficPercentage', parseFloat(value))}
+                    />
+                  </FormGroup>
+                </GridItem>
+                <GridItem span={6}>
+                  <FormGroup
+                    fieldId="trafficStepSize"
+                    label="Traffic Step Size"
+                    isValid={this.state.experiment.trafficControl.trafficStepSize > 0}
+                    helperText="The maximum traffic increment per iteration"
+                    helperTextInvalid="Traffic Step Size must be > 0"
+                  >
+                    <TextInput
+                      id="trafficStepSize"
+                      value={this.state.experiment.trafficControl.trafficStepSize}
+                      placeholder="Traffic Step Size"
+                      onChange={value => this.changeExperimentNumber('trafficStepSize', parseFloat(value))}
+                    />
+                  </FormGroup>
+                </GridItem>
+              </Grid>
+              <FormGroup
+                fieldId="algorithm"
+                label="Algorithm"
+                helperText="Strategy used to analyze the candidate and shift the traffic"
+              >
+                <FormSelect
+                  value={this.state.experiment.trafficControl.algorithm}
+                  id="algorithm"
+                  name="Algorithm"
+                  onChange={value => this.changeExperiment('algorithm', value)}
+                >
+                  {algorithms.map((option, index) => (
+                    <FormSelectOption isDisabled={false} key={'p' + index} value={option} label={option} />
+                  ))}
+                </FormSelect>
+              </FormGroup>
+              <hr />
+              <h1 className="pf-c-title pf-m-xl">Success Criteria</h1>
+              <ExperimentCriteriaForm
+                criterias={this.state.experiment.criterias}
+                onAdd={newCriteria => {
+                  this.setState(prevState => {
+                    prevState.experiment.criterias.push(newCriteria);
+                    return {
+                      iter8Info: prevState.iter8Info,
+                      experiment: {
+                        name: prevState.experiment.name,
+                        namespace: prevState.experiment.namespace,
+                        service: prevState.experiment.service,
+                        apiversion: prevState.experiment.apiversion,
+                        baseline: prevState.experiment.baseline,
+                        candidate: prevState.experiment.candidate,
+                        trafficControl: prevState.experiment.trafficControl,
+                        criterias: prevState.experiment.criterias
+                      }
+                    };
+                  });
+                }}
+                onRemove={index => {
+                  this.setState(prevState => {
+                    prevState.experiment.criterias.splice(index, 1);
+                    return {
+                      iter8Info: prevState.iter8Info,
+                      experiment: {
+                        name: prevState.experiment.name,
+                        namespace: prevState.experiment.namespace,
+                        service: prevState.experiment.service,
+                        apiversion: prevState.experiment.apiversion,
+                        baseline: prevState.experiment.baseline,
+                        candidate: prevState.experiment.candidate,
+                        trafficControl: prevState.experiment.trafficControl,
+                        criterias: prevState.experiment.criterias
+                      }
+                    };
+                  });
+                }}
+              />
+              <ActionGroup>
+                <span style={{ float: 'left', paddingTop: '10px', paddingBottom: '10px' }}>
+                  <span style={{ paddingRight: '5px' }}>
+                    <Button
+                      variant={ButtonVariant.primary}
+                      isDisabled={!isFormValid}
+                      onClick={() => this.createExperiment()}
+                    >
+                      Create
+                    </Button>
+                  </span>
+                  <span style={{ paddingRight: '5px' }}>
+                    <Button
+                      variant={ButtonVariant.secondary}
+                      onClick={() => {
+                        this.goExperimentsPage();
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                  </span>
+                </span>
+              </ActionGroup>
+            </Form>
+          </div>
+        </RenderContent>
+      </>
+    );
+  }
+}
+
+const mapStateToProps = (state: KialiAppState) => ({
+  activeNamespaces: activeNamespacesSelector(state)
+});
+
+const ExperimentCreatePageContainer = connect(
+  mapStateToProps,
+  null
+)(ExperimentCreatePage);
+
+export default ExperimentCreatePageContainer;

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCriteriaForm.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCriteriaForm.tsx
@@ -1,0 +1,276 @@
+import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { Criteria } from './ExperimentCreatePage';
+import * as React from 'react';
+import { Button, FormSelect, FormSelectOption, TextInput, Checkbox } from '@patternfly/react-core';
+import { style } from 'typestyle';
+import { PfColors } from '../../../../components/Pf/PfColors';
+const headerCells: ICell[] = [
+  {
+    title: 'Matric Name',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  },
+  {
+    title: 'Sample Size',
+    transforms: [cellWidth(10) as any],
+    props: {}
+  },
+  {
+    title: 'Tolerance',
+    transforms: [cellWidth(10) as any],
+    props: {}
+  },
+  {
+    title: 'Tolerance Type',
+    transforms: [cellWidth(15) as any],
+    props: {}
+  },
+  {
+    title: 'Stop on Failure',
+    props: {}
+  },
+  {
+    title: '',
+    props: {}
+  }
+];
+
+const metrics = ['', 'iter8_latency', 'iter8_error_count', 'iter8_error_rate'];
+const toleranceType = ['threshold', 'delta'];
+
+const noCriteriaStyle = style({
+  marginTop: 15,
+  color: PfColors.Red100
+});
+
+type Props = {
+  criterias: Criteria[];
+  onAdd: (server: Criteria) => void;
+  onRemove: (index: number) => void;
+};
+
+export type CriteriaState = {
+  criterias: Criteria[];
+};
+
+type State = {
+  addCriteria: Criteria;
+  validName: boolean;
+};
+
+// Create Success Criteria, can be multiple with same metric, but different sampleSize, etc...
+class ExperimentCriteriaForm extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      addCriteria: {
+        metric: '',
+        sampleSize: 100,
+        tolerance: 0.2,
+        toleranceType: 'threshold',
+        stopOnFailure: false
+      },
+      validName: false
+    };
+  }
+
+  // @ts-ignore
+  actionResolver = (rowData, { rowIndex }) => {
+    const removeAction = {
+      title: 'Remove Criteria',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => {
+        this.props.onRemove(rowIndex);
+      }
+    };
+    if (rowIndex < this.props.criterias.length) {
+      return [removeAction];
+    }
+    return [];
+  };
+
+  onAddMetricName = (value: string, _) => {
+    this.setState(prevState => ({
+      addCriteria: {
+        metric: value.trim(),
+        sampleSize: prevState.addCriteria.sampleSize,
+        tolerance: prevState.addCriteria.tolerance,
+        toleranceType: prevState.addCriteria.toleranceType,
+        stopOnFailure: prevState.addCriteria.stopOnFailure
+      },
+      validName: true
+    }));
+  };
+
+  onAddSampleSize = (value: string, _) => {
+    this.setState(prevState => ({
+      addCriteria: {
+        metric: prevState.addCriteria.metric,
+        sampleSize: Number(value.trim()),
+        tolerance: prevState.addCriteria.tolerance,
+        toleranceType: prevState.addCriteria.toleranceType,
+        stopOnFailure: prevState.addCriteria.stopOnFailure
+      },
+      validName: true
+    }));
+  };
+
+  onAddTolerance = (value: string, _) => {
+    this.setState(prevState => ({
+      addCriteria: {
+        metric: prevState.addCriteria.metric,
+        sampleSize: prevState.addCriteria.sampleSize,
+        tolerance: parseFloat(value.trim()),
+        toleranceType: prevState.addCriteria.toleranceType,
+        stopOnFailure: prevState.addCriteria.stopOnFailure
+      },
+      validName: true
+    }));
+  };
+  onAddToleranceType = (value: string, _) => {
+    this.setState(prevState => ({
+      addCriteria: {
+        metric: prevState.addCriteria.metric,
+        sampleSize: prevState.addCriteria.sampleSize,
+        tolerance: prevState.addCriteria.tolerance,
+        toleranceType: value.trim(),
+        stopOnFailure: prevState.addCriteria.stopOnFailure
+      },
+      validName: true
+    }));
+  };
+
+  onAddStopOnFailure = (value: boolean, _) => {
+    this.setState(prevState => ({
+      addCriteria: {
+        metric: prevState.addCriteria.metric,
+        sampleSize: prevState.addCriteria.sampleSize,
+        tolerance: prevState.addCriteria.tolerance,
+        toleranceType: prevState.addCriteria.toleranceType,
+        stopOnFailure: value
+      },
+      validName: true
+    }));
+  };
+
+  onAddCriteria = () => {
+    this.props.onAdd(this.state.addCriteria);
+    this.setState({
+      addCriteria: {
+        metric: '',
+        sampleSize: 100,
+        tolerance: 0.2,
+        toleranceType: 'threshold',
+        stopOnFailure: false
+      }
+    });
+  };
+
+  rows() {
+    return this.props.criterias
+      .map((gw, i) => ({
+        key: 'criteria' + i,
+        cells: [
+          <>{gw.metric}</>,
+          <>{gw.sampleSize}</>,
+          <>{gw.tolerance}</>,
+          <>{gw.toleranceType}</>,
+          <>{gw.stopOnFailure}</>
+        ]
+      }))
+      .concat([
+        {
+          key: 'gwNew',
+          cells: [
+            <>
+              <FormSelect
+                value={this.state.addCriteria.metric}
+                id="addMetricName"
+                name="addMetricName"
+                onChange={this.onAddMetricName}
+              >
+                {metrics.map((option, index) => (
+                  <FormSelectOption isDisabled={false} key={'p' + index} value={option} label={option} />
+                ))}
+              </FormSelect>
+            </>,
+            <>
+              <TextInput
+                value={this.state.addCriteria.sampleSize}
+                type="number"
+                id="addSampleSize"
+                aria-describedby="Sample Size"
+                name="addSampleSize"
+                onChange={this.onAddSampleSize}
+                isValid={!isNaN(this.state.addCriteria.sampleSize)}
+              />
+            </>,
+            <>
+              <TextInput
+                value={this.state.addCriteria.tolerance}
+                type="number"
+                id="addTolerance"
+                aria-describedby="Tolerance"
+                name="addTolerance"
+                onChange={this.onAddTolerance}
+                isValid={!isNaN(this.state.addCriteria.sampleSize)}
+              />
+            </>,
+            <>
+              <FormSelect
+                value={this.state.addCriteria.toleranceType}
+                id="addPortProtocol"
+                name="addPortProtocol"
+                onChange={this.onAddToleranceType}
+              >
+                {toleranceType.map((option, index) => (
+                  <FormSelectOption isDisabled={false} key={'p' + index} value={option} label={option} />
+                ))}
+              </FormSelect>
+            </>,
+            <>
+              <Checkbox
+                label="Stop On Failure"
+                id="stopOnFailure"
+                name="stopOnFailure"
+                aria-label="Stop On Failure"
+                isChecked={this.state.addCriteria.stopOnFailure}
+                onChange={this.onAddStopOnFailure}
+              />
+            </>,
+            <>
+              <Button
+                id="addServerBtn"
+                variant="secondary"
+                isDisabled={this.state.addCriteria.metric.length === 0}
+                onClick={this.onAddCriteria}
+              >
+                Add this Criteria
+              </Button>
+            </>
+          ]
+        }
+      ]);
+  }
+  render() {
+    return (
+      <>
+        <Table
+          aria-label="Success Criterias"
+          cells={headerCells}
+          rows={this.rows()}
+          // @ts-ignore
+          actionResolver={this.actionResolver}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
+        {this.props.criterias.length === 0 && (
+          <div className={noCriteriaStyle}>Experiment has no Success Criteria Defined</div>
+        )}
+      </>
+    );
+  }
+}
+
+export default ExperimentCriteriaForm;

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentDetailsPage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentDetailsPage.tsx
@@ -1,0 +1,247 @@
+import * as React from 'react';
+import { Link, RouteComponentProps } from 'react-router-dom';
+import { RenderHeader } from '../../../../components/Nav/Page';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  Card,
+  CardBody,
+  Grid,
+  GridItem,
+  Stack,
+  StackItem,
+  Text,
+  TextVariants,
+  Title
+} from '@patternfly/react-core';
+import { style } from 'typestyle';
+import * as API from '../../../../services/Api';
+import * as AlertUtils from '../../../../utils/AlertUtils';
+import { Iter8ExpDetailsInfo } from '../../../../types/Iter8';
+import RefreshButtonContainer from '../../../../components/Refresh/RefreshButton';
+import Iter8Dropdown from './Iter8Dropdown';
+import history from '../../../../app/History';
+
+interface Props {
+  namespace: string;
+  name: string;
+}
+
+interface State {
+  experiment?: Iter8ExpDetailsInfo;
+  canDelete: boolean;
+}
+
+const containerPadding = style({ padding: '20px 20px 20px 20px' });
+const tabsPadding = style({ height: '40px', padding: '0px ', backgroundColor: 'white' });
+
+class ExperimentDetailsPage extends React.Component<RouteComponentProps<Props>, State> {
+  constructor(props: RouteComponentProps<Props>) {
+    super(props);
+    this.state = {
+      experiment: undefined,
+      canDelete: false
+    };
+  }
+
+  fetchExperiment = () => {
+    const namespace = this.props.match.params.namespace;
+    const name = this.props.match.params.name;
+    API.getIter8Info()
+      .then(result => {
+        const iter8Info = result.data;
+        if (iter8Info.enabled) {
+          API.getExperiment(namespace, name)
+            .then(result => {
+              this.setState({
+                experiment: result.data,
+                canDelete: result.data.permissions.delete
+              });
+            })
+            .catch(error => {
+              AlertUtils.addError('Could not fetch Iter8 Experiment', error);
+            });
+        } else {
+          AlertUtils.addError('Kiali has Iter8 extension enabled but it is not detected in the cluster');
+        }
+      })
+      .catch(error => {
+        AlertUtils.addError('Could not fetch Iter8 Info.', error);
+      });
+  };
+
+  componentDidMount() {
+    this.fetchExperiment();
+  }
+
+  // Extensions breadcrumb,
+  // It is a simplified view of BreadcrumbView with fixed rendering
+  breadcrumb = () => {
+    return (
+      <div className="breadcrumb">
+        <Breadcrumb>
+          <BreadcrumbItem>
+            <Link to={`/extensions/iter8`}>Iter8 Experiments</Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem>
+            <Link to={`/extensions/iter8?namespaces=${this.props.match.params.namespace}`}>
+              Namespace: {this.props.match.params.namespace}
+            </Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem isActive={true}>{this.props.match.params.name}</BreadcrumbItem>
+        </Breadcrumb>
+      </div>
+    );
+  };
+
+  renderOverview = () => {
+    return (
+      <Card style={{ height: '100%' }}>
+        <CardBody>
+          <Title headingLevel="h3" size="2xl">
+            {' '}
+            Target Service{' '}
+          </Title>
+          <Stack>
+            <StackItem id={'targetService'}>
+              <Text component={TextVariants.h3}> Service </Text>
+              {this.state.experiment ? this.state.experiment.experimentItem.targetService : ''}
+            </StackItem>
+            <StackItem id={'baseline'}>
+              <Text component={TextVariants.h3}> Baseline / Traffic Split</Text>
+              {this.state.experiment
+                ? this.state.experiment.experimentItem.baseline +
+                  ' / ' +
+                  this.state.experiment.experimentItem.baselinePercentage +
+                  ' % '
+                : ''}
+            </StackItem>
+            <StackItem id={'candidate'}>
+              <Text component={TextVariants.h3}> Candidate / Traffic Split</Text>
+              {this.state.experiment
+                ? this.state.experiment.experimentItem.candidate +
+                  ' / ' +
+                  this.state.experiment.experimentItem.candidatePercentage +
+                  ' % '
+                : ''}
+            </StackItem>
+          </Stack>
+        </CardBody>
+      </Card>
+    );
+  };
+
+  renderTrafficControl = () => {
+    return (
+      <Card style={{ height: '100%' }}>
+        <CardBody>
+          <Title headingLevel="h3" size="2xl">
+            {' '}
+            Traffic Control{' '}
+          </Title>
+          <Stack>
+            <StackItem id={'strategy'}>
+              <Text component={TextVariants.h3}> Strategy </Text>
+              {this.state.experiment ? this.state.experiment.trafficControl.algorithm : ''}
+            </StackItem>
+            <StackItem id={'maxIterations'}>
+              <Text component={TextVariants.h3}> Max Iterations </Text>
+              {this.state.experiment ? this.state.experiment.trafficControl.maxIterations : ''}
+            </StackItem>
+            <StackItem id={'maxTrafficPercentage'}>
+              <Text component={TextVariants.h3}> Max Traffic Percentage </Text>
+              {this.state.experiment ? this.state.experiment.trafficControl.maxTrafficPercentage : ''}
+            </StackItem>
+            <StackItem id={'trafficStepSide'}>
+              <Text component={TextVariants.h3}> Traffic Step Side </Text>
+              {this.state.experiment ? this.state.experiment.trafficControl.trafficStepSide : ''}
+            </StackItem>
+          </Stack>
+        </CardBody>
+      </Card>
+    );
+  };
+
+  renderStatus = () => {
+    return (
+      <Card style={{ height: '100%' }}>
+        <CardBody>
+          <Title headingLevel="h3" size="2xl">
+            {' '}
+            Status{' '}
+          </Title>
+          <Stack>
+            <StackItem id={'phase'}>
+              <Text component={TextVariants.h3}> Phase </Text>
+              {this.state.experiment ? this.state.experiment.experimentItem.phase : ''}
+            </StackItem>
+            <StackItem id={'status'}>
+              <Text component={TextVariants.h3}> Status </Text>
+              {this.state.experiment ? this.state.experiment.experimentItem.status : ''}
+            </StackItem>
+            <StackItem id={'started'}>
+              <Text component={TextVariants.h3}> Started </Text>
+              {this.state.experiment ? this.state.experiment.experimentItem.startedAt : ''}
+            </StackItem>
+            <StackItem id={'ended'}>
+              <Text component={TextVariants.h3}> Ended </Text>
+              {this.state.experiment ? this.state.experiment.experimentItem.endedAt : ''}
+            </StackItem>
+          </Stack>
+        </CardBody>
+      </Card>
+    );
+  };
+
+  backToList = () => {
+    // Back to list page
+    history.push(`/extensions/iter8?namespaces=${this.props.match.params.namespace}`);
+  };
+
+  doRefresh = () => {
+    this.fetchExperiment();
+  };
+
+  doDelete = () => {
+    API.deleteExperiment(this.props.match.params.namespace, this.props.match.params.name)
+      .then(() => this.backToList())
+      .catch(error => {
+        AlertUtils.addError('Could not delete Iter8 Experiment.', error);
+      });
+  };
+
+  renderRightToolbar = () => {
+    return (
+      <span style={{ position: 'absolute', right: '50px', zIndex: 1 }}>
+        <RefreshButtonContainer handleRefresh={this.doRefresh} />
+        <Iter8Dropdown
+          experimentName={this.props.match.params.name}
+          canDelete={this.state.canDelete}
+          onDelete={this.doDelete}
+        />
+      </span>
+    );
+  };
+
+  render() {
+    return (
+      <>
+        <RenderHeader>
+          {this.breadcrumb()}
+          <Text component={TextVariants.h1}>{this.props.match.params.name}</Text>
+          {this.renderRightToolbar()}
+        </RenderHeader>
+        <div className={tabsPadding} />
+        <div className={containerPadding}>
+          <Grid gutter={'md'}>
+            <GridItem span={4}>{this.renderOverview()}</GridItem>
+            <GridItem span={4}>{this.renderTrafficControl()}</GridItem>
+            <GridItem span={4}>{this.renderStatus()}</GridItem>
+          </Grid>
+        </div>
+      </>
+    );
+  }
+}
+
+export default ExperimentDetailsPage;

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/Iter8Dropdown.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/Iter8Dropdown.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import {
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownPosition,
+  DropdownToggle,
+  Modal,
+  Text,
+  TextVariants
+} from '@patternfly/react-core';
+
+type Props = {
+  experimentName: string;
+  canDelete: boolean;
+  onDelete: () => void;
+};
+
+type State = {
+  showConfirmModal: boolean;
+  dropdownOpen: boolean;
+};
+
+class Iter8Dropdown extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      dropdownOpen: false,
+      showConfirmModal: false
+    };
+  }
+
+  onSelect = _ => {
+    this.setState({
+      dropdownOpen: !this.state.dropdownOpen
+    });
+  };
+
+  onToggle = (dropdownState: boolean) => {
+    this.setState({
+      dropdownOpen: dropdownState
+    });
+  };
+
+  hideConfirmModal = () => {
+    this.setState({ showConfirmModal: false });
+  };
+
+  onClickDelete = () => {
+    this.setState({ showConfirmModal: true });
+  };
+
+  onDelete = () => {
+    this.hideConfirmModal();
+    this.props.onDelete();
+  };
+
+  render() {
+    return (
+      <>
+        <Dropdown
+          id="actions"
+          title="Actions"
+          toggle={<DropdownToggle onToggle={this.onToggle}>Actions</DropdownToggle>}
+          onSelect={this.onSelect}
+          position={DropdownPosition.right}
+          isOpen={this.state.dropdownOpen}
+          dropdownItems={[
+            <DropdownItem key="deleteExperiment" onClick={this.onClickDelete} isDisabled={!this.props.canDelete}>
+              Delete
+            </DropdownItem>
+          ]}
+        />
+        <Modal
+          title="Confirm Delete"
+          isSmall={true}
+          isOpen={this.state.showConfirmModal}
+          onClose={this.hideConfirmModal}
+          actions={[
+            <Button key="cancel" variant="secondary" onClick={this.hideConfirmModal}>
+              Cancel
+            </Button>,
+            <Button key="confirm" variant="danger" onClick={this.onDelete}>
+              Delete
+            </Button>
+          ]}
+        >
+          <Text component={TextVariants.p}>
+            Are you sure you want to delete the Iter8 Experiment {this.props.experimentName} ? It cannot be undone. Make
+            sure this is something you really want to do!
+          </Text>
+        </Modal>
+      </>
+    );
+  }
+}
+
+export default Iter8Dropdown;

--- a/src/pages/extensions/iter8/Iter8ExperimentList/ExperimentListContainer.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentList/ExperimentListContainer.tsx
@@ -1,0 +1,345 @@
+import * as React from 'react';
+import {
+  Badge,
+  Dropdown,
+  DropdownItem,
+  DropdownPosition,
+  DropdownToggle,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Title,
+  Toolbar,
+  ToolbarSection,
+  Tooltip,
+  TooltipPosition
+} from '@patternfly/react-core';
+import { style } from 'typestyle';
+import {
+  sortable,
+  Table,
+  TableBody,
+  TableHeader,
+  ISortBy,
+  IRow,
+  SortByDirection,
+  cellWidth
+} from '@patternfly/react-table';
+import * as API from '../../../../services/Api';
+import * as AlertUtils from '../../../../utils/AlertUtils';
+import history from '../../../../app/History';
+import { Iter8Info, Iter8Experiment } from '../../../../types/Iter8';
+import { Link } from 'react-router-dom';
+import * as FilterComponent from '../../../../components/FilterList/FilterComponent';
+
+import RefreshButtonContainer from '../../../../components/Refresh/RefreshButton';
+import { KialiAppState } from '../../../../store/Store';
+import { activeNamespacesSelector } from '../../../../store/Selectors';
+import { connect } from 'react-redux';
+import Namespace from '../../../../types/Namespace';
+import { PromisesRegistry } from '../../../../utils/CancelablePromises';
+import { namespaceEquals } from '../../../../utils/Common';
+
+// Style constants
+const rightToolbar = style({ marginLeft: 'auto' });
+const containerPadding = style({ padding: '20px 20px 20px 20px' });
+
+interface Props extends FilterComponent.Props<Iter8Experiment> {
+  activeNamespaces: Namespace[];
+}
+
+// State of the component/page
+// It stores the visual state of the components and the experiments fetched from the backend.
+interface State extends FilterComponent.State<Iter8Experiment> {
+  iter8Info: Iter8Info;
+  experimentLists: Iter8Experiment[];
+  sortBy: ISortBy; // ?? not used yet
+  dropdownOpen: boolean;
+}
+
+const columns = [
+  {
+    title: 'Name',
+    transforms: [sortable]
+  },
+  {
+    title: 'Namespace',
+    transforms: [sortable]
+  },
+  {
+    title: 'Phase',
+    transforms: [sortable, cellWidth(15) as any]
+  },
+  {
+    title: 'Status',
+    transforms: [sortable]
+  },
+  {
+    title: 'Baseline',
+    transforms: [sortable]
+  },
+  {
+    title: 'Candidate',
+    transforms: [sortable]
+  }
+];
+
+class ExperimentListPage extends React.Component<Props, State> {
+  private promises = new PromisesRegistry();
+
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      iter8Info: {
+        enabled: false
+      },
+      experimentLists: [],
+      sortBy: {},
+      dropdownOpen: false,
+      listItems: [],
+      currentSortField: this.props.currentSortField,
+      isSortAscending: this.props.isSortAscending
+    };
+  }
+
+  fetchExperiments = (namespaces: string[]) => {
+    API.getIter8Info()
+      .then(result => {
+        const iter8Info = result.data;
+        if (iter8Info.enabled) {
+          API.getExperiments(namespaces)
+            .then(result => {
+              this.setState(prevState => {
+                return {
+                  iter8Info: iter8Info,
+                  experimentLists: result.data,
+                  sortBy: prevState.sortBy
+                };
+              });
+            })
+            .catch(error => {
+              AlertUtils.addError('Could not fetch Iter8 Experiments.', error);
+            });
+        } else {
+          AlertUtils.addError('Kiali has Iter8 extension enabled but it is not detected in the cluster');
+        }
+      })
+      .catch(error => {
+        AlertUtils.addError('Could not fetch Iter8 Info.', error);
+      });
+  };
+
+  // It invokes backend when component is mounted
+  componentDidMount() {
+    this.updateListItems();
+  }
+
+  componentDidUpdate(prevProps: Props, _prevState: State, _snapshot: any) {
+    const [paramsSynced] = this.paramsAreSynced(prevProps);
+    if (!paramsSynced) {
+      this.setState({
+        currentSortField: this.props.currentSortField,
+        isSortAscending: this.props.isSortAscending
+      });
+
+      this.updateListItems();
+    }
+  }
+
+  componentWillUnmount() {
+    this.promises.cancelAll();
+  }
+
+  paramsAreSynced = (prevProps: Props): [boolean, boolean] => {
+    const activeNamespacesCompare = namespaceEquals(prevProps.activeNamespaces, this.props.activeNamespaces);
+    const paramsSynced =
+      activeNamespacesCompare &&
+      prevProps.isSortAscending === this.props.isSortAscending &&
+      prevProps.currentSortField.title === this.props.currentSortField.title;
+    return [paramsSynced, activeNamespacesCompare];
+  };
+
+  // Helper used for Table to sort handlers based on index column == field
+  onSort = (_event, index, direction) => {
+    const experimentList = this.state.experimentLists.sort((a, b) => {
+      switch (index) {
+        case 0:
+          return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+        case 1:
+          return a.namespace < b.namespace ? -1 : a.namespace > b.namespace ? 1 : 0;
+        case 2:
+          return a.phase < b.phase ? -1 : a.phase > b.phase ? 1 : 0;
+        case 3:
+          return a.status < b.status ? -1 : a.status > b.status ? 1 : 0;
+        case 4:
+          return a.baseline < b.baseline ? -1 : a.baseline > b.baseline ? 1 : 0;
+        case 5:
+          return a.candidate < b.candidate ? -1 : a.candidate > b.candidate ? 1 : 0;
+      }
+      return 0;
+    });
+    this.setState({
+      experimentLists: direction === SortByDirection.asc ? experimentList : experimentList.reverse(),
+      sortBy: {
+        index,
+        direction
+      }
+    });
+  };
+
+  updateListItems() {
+    this.promises.cancelAll();
+    const namespacesSelected = this.props.activeNamespaces.map(item => item.name);
+    if (namespacesSelected.length === 0) {
+      this.promises
+        .register('namespaces', API.getNamespaces())
+        .then(namespacesResponse => {
+          const namespaces: Namespace[] = namespacesResponse.data;
+          this.fetchExperiments(namespaces.map(namespace => namespace.name));
+        })
+        .catch(namespacesError => {
+          if (!namespacesError.isCanceled) {
+            AlertUtils.addError('Could not fetch namespace list.', namespacesError);
+          }
+        });
+    } else {
+      this.fetchExperiments(namespacesSelected);
+    }
+  }
+
+  // Invoke the history object to update and URL and start a routing
+  goNewExperimentPage = () => {
+    history.push('/extensions/iter8/new');
+  };
+
+  // This is a simplified actions toolbar.
+  // It contains a create new handler action.
+  actionsToolbar = () => {
+    return (
+      <Dropdown
+        id="actions"
+        title="Actions"
+        toggle={<DropdownToggle onToggle={toggle => this.setState({ dropdownOpen: toggle })}>Actions</DropdownToggle>}
+        onSelect={() => this.setState({ dropdownOpen: !this.state.dropdownOpen })}
+        position={DropdownPosition.right}
+        isOpen={this.state.dropdownOpen}
+        dropdownItems={[
+          <DropdownItem
+            key="createExperiment"
+            isDisabled={!this.state.iter8Info.enabled}
+            onClick={() => this.goNewExperimentPage()}
+          >
+            Create New Experiment
+          </DropdownItem>
+        ]}
+      />
+    );
+  };
+
+  // This is a simplified toolbar for refresh and actions.
+  // Kiali has a shared component toolbar for more complex scenarios like filtering
+  // It renders actions only if user has permissions
+  toolbar = () => {
+    return (
+      <Toolbar className="pf-l-toolbar pf-u-justify-content-space-between pf-u-mx-xl pf-u-my-md">
+        <ToolbarSection aria-label="ToolbarSection">
+          <Toolbar className={rightToolbar}>
+            <RefreshButtonContainer key={'Refresh'} handleRefresh={() => this.updateListItems()} />
+            {this.actionsToolbar()}
+          </Toolbar>
+        </ToolbarSection>
+      </Toolbar>
+    );
+  };
+
+  // Helper used to build the table content.
+  rows = (): IRow[] => {
+    return this.state.experimentLists.map(h => {
+      return {
+        cells: [
+          <>
+            <Tooltip
+              key={'TooltipExtensionIter8Name_' + h.name}
+              position={TooltipPosition.top}
+              content={<>Iter8 Experiment</>}
+            >
+              <Badge className={'virtualitem_badge_definition'}>IT8</Badge>
+            </Tooltip>
+            <Link
+              to={`/extensions/namespaces/${h.namespace}/iter8/${h.name}`}
+              key={'Experiment_' + h.namespace + '_' + h.namespace}
+            >
+              {h.name}
+            </Link>
+          </>,
+          <>
+            <Tooltip
+              key={'TooltipExtensionNamespace_' + h.namespace}
+              position={TooltipPosition.top}
+              content={<>Namespace</>}
+            >
+              <Badge className={'virtualitem_badge_definition'}>NS</Badge>
+            </Tooltip>
+            {h.namespace}
+          </>,
+          <>{h.phase}</>,
+          <>{h.status}</>,
+          <>
+            {h.baseline} <br /> {h.baselinePercentage}%
+          </>,
+          <>
+            {h.candidate}
+            <br /> {h.candidatePercentage}%
+          </>
+        ]
+      };
+    });
+  };
+
+  render() {
+    return (
+      <div className={containerPadding}>
+        {this.toolbar()}
+        <Table
+          aria-label="Sortable Table"
+          sortBy={this.state.sortBy}
+          cells={columns}
+          rows={this.rows()}
+          onSort={this.onSort}
+        >
+          <TableHeader />
+          {this.state.experimentLists.length > 0 ? (
+            <TableBody />
+          ) : (
+            <tr>
+              <td colSpan={columns.length}>
+                <EmptyState variant={EmptyStateVariant.full}>
+                  <Title headingLevel="h5" size="lg">
+                    No Iter8 Experiments found
+                  </Title>
+                  <EmptyStateBody>
+                    No Iter8 Experiments in namespace
+                    {this.props.activeNamespaces.length === 1
+                      ? ` ${this.props.activeNamespaces[0].name}`
+                      : `s: ${this.props.activeNamespaces.map(ns => ns.name).join(', ')}`}
+                  </EmptyStateBody>
+                </EmptyState>
+              </td>
+            </tr>
+          )}
+        </Table>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state: KialiAppState) => ({
+  activeNamespaces: activeNamespacesSelector(state)
+});
+
+const ExperimentListPageContainer = connect(
+  mapStateToProps,
+  null
+)(ExperimentListPage);
+
+export default ExperimentListPageContainer;

--- a/src/pages/extensions/iter8/Iter8ExperimentList/ExperimentListPage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentList/ExperimentListPage.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import * as FilterHelper from '../../../../components/FilterList/FilterHelper';
+import { RenderContent } from '../../../../components/Nav/Page';
+import ExperimentListContainer from './ExperimentListContainer';
+import * as ExpListFilters from './FiltersAndSorts';
+
+const ExperimentListPage: React.SFC<{}> = () => {
+  return (
+    <RenderContent>
+      <ExperimentListContainer
+        currentSortField={FilterHelper.currentSortField(ExpListFilters.sortFields)}
+        isSortAscending={FilterHelper.isCurrentSortAscending()}
+        activeNamespaces={[]}
+      />
+    </RenderContent>
+  );
+};
+
+export default ExperimentListPage;

--- a/src/pages/extensions/iter8/Iter8ExperimentList/FiltersAndSorts.ts
+++ b/src/pages/extensions/iter8/Iter8ExperimentList/FiltersAndSorts.ts
@@ -1,0 +1,72 @@
+import { FILTER_ACTION_APPEND, FilterType } from '../../../../types/Filters';
+import { SortField } from '../../../../types/SortFilters';
+import { Iter8Experiment } from '../../../../types/Iter8';
+import { TextInputTypes } from '@patternfly/react-core';
+
+// Place Holder, not quite finished yet. Or if filter is needed, and how to use the common filters?
+
+export const sortFields: SortField<Iter8Experiment>[] = [
+  {
+    id: 'namespace',
+    title: 'Namespace',
+    isNumeric: false,
+    param: 'ns',
+    compare: (a, b) => {
+      let sortValue = a.namespace.localeCompare(b.namespace);
+      if (sortValue === 0) {
+        sortValue = a.name.localeCompare(b.name);
+      }
+      return sortValue;
+    }
+  },
+  {
+    id: 'name',
+    title: 'Name',
+    isNumeric: false,
+    param: 'wn',
+    compare: (a, b) => a.name.localeCompare(b.name)
+  },
+  {
+    id: 'phase',
+    title: 'Phase',
+    isNumeric: false,
+    param: 'is',
+    compare: (a, b) => a.name.localeCompare(b.name)
+  },
+  {
+    id: 'baseline',
+    title: 'Baseline',
+    isNumeric: false,
+    param: 'is',
+    compare: (a, b) => a.name.localeCompare(b.name)
+  },
+  {
+    id: 'candidate',
+    title: 'Candidate',
+    isNumeric: false,
+    param: 'is',
+    compare: (a, b) => a.name.localeCompare(b.name)
+  }
+];
+
+const appNameFilter: FilterType = {
+  id: 'name',
+  title: 'Name',
+  placeholder: 'Filter by Experiment Name',
+  filterType: TextInputTypes.text,
+  action: FILTER_ACTION_APPEND,
+  filterValues: []
+};
+
+export const availableFilters: FilterType[] = [appNameFilter];
+
+/** Sort Method */
+
+export const sortAppsItems = (
+  unsorted: Iter8Experiment[],
+  sortField: SortField<Iter8Experiment>,
+  isAscending: boolean
+): Promise<Iter8Experiment[]> => {
+  const sorted = unsorted.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a));
+  return Promise.resolve(sorted);
+};

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -14,6 +14,9 @@ import DefaultSecondaryMasthead from './components/DefaultSecondaryMasthead/Defa
 import IstioConfigNewPageContainer from './pages/IstioConfigNew/IstioConfigNewPage';
 import ThreeScaleHandlerListPage from './pages/extensions/threescale/ThreeScaleHandlerList/ThreeScaleHandlerListPage';
 import ThreeScaleHandlerDetailsPage from './pages/extensions/threescale/ThreeScaleHandlerDetails/ThreeScaleHandlerDetailsPage';
+import ExperimentListPage from './pages/extensions/iter8/Iter8ExperimentList/ExperimentListPage';
+import ExperimentCreatePageContainer from './pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage';
+import ExperimentDetailsPage from './pages/extensions/iter8/Iter8ExperimentDetails/ExperimentDetailsPage';
 
 /**
  * Return array of objects that describe vertical menu
@@ -61,6 +64,11 @@ const extensionsItems: MenuItem[] = [
     title: '3scale Config',
     to: '/extensions/threescale',
     pathsActive: [/^\/extensions\/threescale/]
+  },
+  {
+    title: 'Iter8 Experiments',
+    to: '/extensions/iter8',
+    pathsActive: [/^\/extensions\/iter8/, new RegExp('^/extensions/namespaces/(.*)/iter8')]
   }
 ];
 
@@ -162,6 +170,10 @@ const secondaryMastheadRoutes: Path[] = [
   {
     path: '/' + Paths.JAEGER,
     component: DefaultSecondaryMasthead
+  },
+  {
+    path: '/extensions/iter8',
+    component: DefaultSecondaryMasthead
   }
 ];
 
@@ -178,6 +190,20 @@ const extensionsRoutes: Path[] = [
   {
     path: '/extensions/threescale',
     component: ThreeScaleHandlerListPage
+  },
+  // Extension will follow /extensions/<extension>/namespaces/:namespace/experiments/:name pattern
+  // To make RenderPage.tsx routes easy to filter without regex
+  {
+    path: '/extensions/namespaces/:namespace/iter8/:name',
+    component: ExperimentDetailsPage
+  },
+  {
+    path: '/extensions/iter8/new',
+    component: ExperimentCreatePageContainer
+  },
+  {
+    path: '/extensions/iter8',
+    component: ExperimentListPage
   }
 ];
 

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -32,7 +32,7 @@ import { Pod, PodLogs, ValidationStatus } from '../types/IstioObjects';
 import { ThreeScaleHandler, ThreeScaleInfo, ThreeScaleServiceRule } from '../types/ThreeScale';
 import { GrafanaInfo } from '../types/GrafanaInfo';
 import { Span, TracingQuery } from 'types/Tracing';
-
+import { Iter8Info, Iter8Experiment, Iter8ExpDetailsInfo } from '../types/Iter8';
 export const ANONYMOUS_USER = 'anonymous';
 
 export interface Response<T> {
@@ -531,4 +531,32 @@ export const getServiceSpans = (namespace: string, service: string, params: Trac
 
 export const getIstioPermissions = (namespaces: string[]) => {
   return newRequest<IstioPermissions>(HTTP_VERBS.GET, urls.istioPermissions, { namespaces: namespaces.join(',') }, {});
+};
+
+export const getIter8Info = () => {
+  return newRequest<Iter8Info>(HTTP_VERBS.GET, urls.iter8, {}, {});
+};
+
+export const getExperiments = (namespaces: string[]) => {
+  return newRequest<Iter8Experiment[]>(HTTP_VERBS.GET, urls.iter8Experiments, { namespaces: namespaces.join(',') }, {});
+};
+
+export const getExperimentsByNamespace = (namespace: string) => {
+  return newRequest<Iter8Experiment>(HTTP_VERBS.GET, urls.iter8ExperimentsByNamespace(namespace), {}, {});
+};
+
+export const getExperiment = (namespace: string, name: string) => {
+  return newRequest<Iter8ExpDetailsInfo>(HTTP_VERBS.GET, urls.iter8Experiment(namespace, name), {}, {});
+};
+
+export const deleteExperiment = (namespace: string, name: string) => {
+  return newRequest<Iter8Experiment>(HTTP_VERBS.DELETE, urls.iter8Experiment(namespace, name), {}, {});
+};
+
+export const createExperiment = (namespace: string, specBody: string) => {
+  return newRequest<Iter8Experiment>(HTTP_VERBS.POST, urls.iter8ExperimentsByNamespace(namespace), {}, specBody);
+};
+
+export const updateExperiment = (namespace: string, name: string, specBody: string) => {
+  return newRequest<Iter8Experiment>(HTTP_VERBS.POST, urls.iter8Experiment(namespace, name), {}, specBody);
 };

--- a/src/types/Iter8.ts
+++ b/src/types/Iter8.ts
@@ -1,0 +1,72 @@
+import { ResourcePermissions } from './Permissions';
+
+export interface Iter8Info {
+  enabled: boolean;
+}
+
+export interface Iter8Experiment {
+  name: string;
+  phase: string;
+  status: string;
+  baseline: string;
+  baselinePercentage: number;
+  candidate: string;
+  candidatePercentage: number;
+  namespace: string;
+}
+
+export interface ExpId {
+  namespace: string;
+  name: string;
+}
+
+export interface TrafficControl {
+  algorithm: string;
+  interval: string;
+  maxIterations: number;
+  maxTrafficPercentage: number;
+  trafficStepSide: number;
+}
+
+export interface Iter8ExpDetailsInfo {
+  experimentItem: ExperimentItem;
+  criterias: SuccessCriteria[];
+  trafficControl: TrafficControl;
+  permissions: ResourcePermissions;
+}
+
+export interface ExperimentItem {
+  name: string;
+  namespace: string;
+  phase: string;
+  status: string;
+  createdAt: string;
+  startedAt: string;
+  endedAt: string;
+  baseline: string;
+  baselinePercentage: number;
+  candidate: string;
+  candidatePercentage: number;
+  targetService: string;
+  targetServiceNamespace: string;
+  labels?: { [key: string]: string };
+  resourceVersion: string;
+}
+export interface SuccessCriteria {
+  name: string;
+  criteria: Criteria;
+  metric: Metric;
+}
+export interface Metric {
+  absent_value: string;
+  is_count: boolean;
+  query_template: string;
+  sample_size_template: string;
+}
+export interface Criteria {
+  metric: string;
+  tolerance: number;
+  toleranceType: string;
+  sampleSize: number;
+  stopOnFailure: boolean;
+}

--- a/src/types/ServerConfig.ts
+++ b/src/types/ServerConfig.ts
@@ -6,10 +6,13 @@ export type IstioLabelKey = 'appLabelName' | 'versionLabelName';
 interface ThreeScaleConfig {
   enabled: boolean;
 }
-
+interface iter8Config {
+  enabled: boolean;
+}
 // Kiali addons/extensions specific
 interface Extensions {
   threescale: ThreeScaleConfig;
+  iter8: iter8Config;
 }
 
 export interface ServerConfig {

--- a/src/utils/CancelablePromises.ts
+++ b/src/utils/CancelablePromises.ts
@@ -75,4 +75,8 @@ export class PromisesRegistry {
       this.promises.delete(key);
     }
   }
+
+  has(key: string): boolean {
+    return this.promises.has(key);
+  }
 }


### PR DESCRIPTION
* Add Iter8 feature

Listing Experiment List page - (issue#2453)

* Fix Build Error/warning

* Arrange Iter8 Create page

* Improve Iter8 Create page

* Complete Iter8 Create scenario

* Iter8 Details page work

* Add Iter8 details page

* More fixes in details pages

* Easy select services and deployments on Iter8

* Cornercase when service has no workloads

* Adjust properties in Experiment*

* Update yarn version in travis

* Lock yarn version

* Adjust PR after rebase

* Support delete Iter8 experiment

* Minor fixes

* Remove unnecessary log

* Title fix when deploying on minikube

Co-authored-by: Yew-Huey Liu <yhliu@us.ibm.com>

** Describe the change **

_explanation of what it does_

** Issue reference **

* If this is a fix for a JIRA, please put JIRA-reference in the PR title like _`KIALI-7 New icons`_ (Jira-id, one space, description)
* If this is a fix for a GH-issue, please link it here

** Backwards compatible? **

[ ] Is your pull-request introducing changes in behaviour?

_Describe the changes if appropriate. E.g. a new link, a change on what a click does, etc_

** Screenshot **

Add a screenshot of the UI after your changes.

** Documentation **

Please provide an update to documentation if appropriate. For configuration options, consider sending a PR to https://github.com/kiali/kiali/blob/master/README.adoc
